### PR TITLE
extend java.util.Date with PCodec/decode fn to support Joda date-time

### DIFF
--- a/src/qbits/alia/codec/joda_time.clj
+++ b/src/qbits/alia/codec/joda_time.clj
@@ -8,3 +8,8 @@
   org.joda.time.DateTime
   (encode [x]
     (.toDate x)))
+
+(extend-protocol codec/PCodec
+  java.util.Date
+  (decode [x]
+    (ct/to-date-time x)))


### PR DESCRIPTION
custom decoder for date->date-time

related to #26 