### PR TITLE
added lz4 compression to docs and dev profile

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -66,7 +66,7 @@ The following options are supported:
   Cassandra's PasswordAuthenticator
 
 * `:compression` : Compression supported by the Cassandra binary
-  protocol. Can be `:none` or `:snappy`.
+  protocol. Can be `:none`, `:snappy` or `:lz4`.
 
 * `:ssl?`: enables/disables SSL
 

--- a/project.clj
+++ b/project.clj
@@ -16,6 +16,7 @@
              :1.6  {:dependencies [[org.clojure/clojure "1.6.0"]]}
              :1.7  {:dependencies [[org.clojure/clojure "1.7.0-SNAPSHOT"]]}
              :dev  {:dependencies [[org.xerial.snappy/snappy-java "1.0.5"]
+                                   [net.jpountz.lz4/lz4 "1.2.0"]
                                    [clj-time "0.8.0"]
                                    [com.taoensso/nippy "2.8.0"]
                                    [cc.qbits/tardis "1.0.0"]

--- a/src/qbits/alia.clj
+++ b/src/qbits/alia.clj
@@ -76,7 +76,7 @@ The following options are supported:
   Cassandra's PasswordAuthenticator
 
 * `:compression` : Compression supported by the Cassandra binary
-  protocol. Can be `:none` or `:snappy`.
+  protocol. Can be `:none`, `:snappy` or `:lz4`.
 
 * `:cluster-name` : Optional name for create cluster
 


### PR DESCRIPTION
Documented lz4 compression option, added lz4 dependency to development profile.

lz4 is supported by cassandra driver (2.1) and is present in [ProtocolOptions.Compression](http://docs.datastax.com/en/drivers/java/2.1/com/datastax/driver/core/ProtocolOptions.Compression.html).

Since the ProtocolOptions.Compression enum is just [converted](https://github.com/mpenet/alia/blob/master/src/qbits/alia/enum.clj#L14) to keyword and recognized, lz4 compression also automatically supported by alia.

The lz4 jar, needed for compression, is optional in cassandra driver and should be explitly specified by driver user.
The version of expected lz4 jar is specified in [cassandra-driver-parent-2.1.6.pom](https://repo1.maven.org/maven2/com/datastax/cassandra/cassandra-driver-parent/2.1.6/cassandra-driver-parent-2.1.6.pom)

