### PR TITLE
Issue #29, NoHostAvailableException. Lamina and Manifold modifications

### DIFF
--- a/src/qbits/alia/lamina.clj
+++ b/src/qbits/alia/lamina.clj
@@ -41,8 +41,12 @@
           rs-future
           (reify FutureCallback
             (onSuccess [_ result]
-              (l/success async-result
-                         (codec/result-set->maps (.get rs-future) string-keys?)))
+              (try
+                (l/success async-result
+                           (codec/result-set->maps (.get rs-future) string-keys?))
+                (catch Exception err
+                  (l/error async-result
+                           (ex->ex-info err {:query statement :values values})))))
             (onFailure [_ ex]
               (l/error async-result
                        (ex->ex-info ex {:query statement :values values}))))


### PR DESCRIPTION
extend protection around ResultSet throwing NoHostAvailable exceptions to Lamina and Manifold impl.