### PR TITLE
exclude netty from cassandra-driver-dse dependency

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,8 @@
                  [com.datastax.cassandra/cassandra-driver-core ~driver-version
                   :classifier "shaded"
                   :exclusions [io.netty/*]]
-                 [com.datastax.cassandra/cassandra-driver-dse ~driver-version]
+                 [com.datastax.cassandra/cassandra-driver-dse ~driver-version
+                  :exclusions [io.netty/*]]
                  [org.clojure/core.async "0.1.346.0-17112a-alpha"]]
   :profiles {:1.4  {:dependencies [[org.clojure/clojure "1.4.0"]]}
              :1.5  {:dependencies [[org.clojure/clojure "1.5.1"]]}


### PR DESCRIPTION
Sorry, I should have noticed when shading/excluding the first time around. Because the shaded JAR uses the original POM, you still need to exclude the dependency explicitly, and that includes in the cassandra-driver-dse dependency (because it brings in cassandra-driver-core itself).