### PR TITLE
never register nil on-realized callbacks

### DIFF
--- a/src/qbits/alia/manifold.clj
+++ b/src/qbits/alia/manifold.clj
@@ -34,7 +34,7 @@
                                  consistency serial-consistency fetch-size
                                  timestamp paging-state)
          (let [^ResultSetFuture rs-future (.executeAsync session statement)]
-           (d/on-realized deferred success error)
+           (d/on-realized deferred (or success (fn [_])) (or error (fn [])))
            (Futures/addCallback
              rs-future
              (reify FutureCallback

--- a/src/qbits/alia/manifold.clj
+++ b/src/qbits/alia/manifold.clj
@@ -34,7 +34,7 @@
                                  consistency serial-consistency fetch-size
                                  timestamp paging-state)
          (let [^ResultSetFuture rs-future (.executeAsync session statement)]
-           (d/on-realized deferred (or success (fn [_])) (or error (fn [])))
+           (d/on-realized deferred (or success (fn [_])) (or error (fn [_])))
            (Futures/addCallback
              rs-future
              (reify FutureCallback


### PR DESCRIPTION
nil callbacks cause an exception to be logged from manifold