### PR TITLE
correct cassandra-driver-dse exclusions

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,7 @@
                   :classifier "shaded"
                   :exclusions [io.netty/*]]
                  [com.datastax.cassandra/cassandra-driver-dse ~driver-version
-                  :exclusions [io.netty/*]]
+                  :exclusions [com.datastax.cassandra/cassandra-driver-core]]
                  [org.clojure/core.async "0.2.371"]]
   :profiles {:1.8  {:dependencies [[org.clojure/clojure "1.8.0-SNAPSHOT"]]}
              :dev  {:dependencies [[org.xerial.snappy/snappy-java "1.0.5"]


### PR DESCRIPTION
Alia uses the shaded version of the Datastax Java Driver, that suits me because I run a suite of applications that are built on Netty, and sometimes the version that I'm using (current: 4.0.30) differs from that of the driver (current: 4.0.27).

Alia includes com.datastax.cassandra/cassandra-driver-dse which has a dependency on com.datastax.cassandra/cassandra-driver-core (not shaded), originally I excluded netty from dse:

```
[com.datastax.cassandra/cassandra-driver-dse ~driver-version :exclusions [io.netty/*]]
```

more correctly, that driver-dse should exclude driver-core

```
[com.datastax.cassandra/cassandra-driver-dse ~driver-version :exclusions [com.datastax.cassandra/cassandra-driver-core]]
```

Otherwise it's possible (happens in my Jenkins builds) that the non-shaded version of driver-core supersedes shaded on the classpath, but there's no Netty (it's been excluded) and you see an error like:

```
Caused by: java.lang.NoClassDefFoundError: io/netty/util/Timer
	at com.datastax.driver.core.Cluster$Builder.<init>(Cluster.java:685)
	at com.datastax.driver.core.Cluster.builder(Cluster.java:193)
	at qbits.alia$cluster.invoke(alia.clj:183)
	at smx.eventstore.cassandra.core$eval13118$__GT_cluster__13119$fn__13120.invoke(core.clj:197)
	at smx.eventstore.cassandra.core$eval13118$__GT_cluster__13119.invoke(core.clj:194)
```

For more info, see the similar example of excluding driver-core from cassandra-driver-mapper here:

https://github.com/datastax/java-driver/blob/4a17af6af768b77796055dba9ba1e12bd1098b45/features/shaded_jar/README.md