### PR TITLE
Allow non-primary key named-bindings to be optional

### DIFF
--- a/src/qbits/alia.clj
+++ b/src/qbits/alia.clj
@@ -22,7 +22,8 @@
     ResultSetFuture
     Session
     SimpleStatement
-    Statement)
+    Statement
+    ColumnDefinitions$Definition)
    (com.google.common.util.concurrent
     MoreExecutors
     Futures
@@ -236,10 +237,9 @@ pools/connections"
   (try
     (if (map? values)
       (let [bound (.bind statement)]
-        (doseq [[k x] values]
-          (codec/set-named-parameter! bound
-                                      (name k)
-                                      (codec/encode x)))
+        (doseq [^ColumnDefinitions$Definition column (.getVariables statement)]
+          (let [binding-name (.getName column)]
+            (codec/set-named-parameter! bound binding-name (codec/encode (get values (keyword binding-name))))))
         bound)
       (.bind statement (to-array (map codec/encode values))))
     (catch Exception ex


### PR DESCRIPTION
Currently when using named bindings the values map is expected to be the full set (and nothing more) of named bindings applicable to the PreparedStatement.

This PR inverts the responsibility, we find the bindings available on the PreparedStatement and look each one up in the values map.

This has the advantage (I think) of allowing non-primary key bindings to be optional in the values map, and ignoring values which are not defined by the underlying query.

It helps me in some circumstances when writing events where some values are optional, it's a minor annoyance but I find myself currently doing something similar to:

```clojure
(merge {:optional-val nil} values)
```

prior to executing, otherwise the named binding fails.