### PR TITLE
Fix :credentials key name in guide

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -62,7 +62,7 @@ The following options are supported:
 
 * `:jmx-reporting?` : Toggles JMX reporting of the metrics.
 
-* `:credentials` : Takes a map of :username and :password for use with
+* `:credentials` : Takes a map of :user and :password for use with
   Cassandra's PasswordAuthenticator
 
 * `:compression` : Compression supported by the Cassandra binary


### PR DESCRIPTION
It's the same as this one https://github.com/mpenet/alia/issues/13, but which fixes the guide.
