### PR TITLE
use manifold/connect for lazy-seq to stream

### DIFF
--- a/modules/alia-manifold/src/qbits/alia/manifold.clj
+++ b/modules/alia-manifold/src/qbits/alia/manifold.clj
@@ -91,16 +91,10 @@
              rs-future
              (reify FutureCallback
                (onSuccess [_ result]
-                 (try
-                   (loop [rows (codec/result-set->maps (.get rs-future)
-                                                       result-set-fn
-                                                       key-fn)]
-                     (when-let [row (first rows)]
-                       (when (s/put! stream row)
-                         (recur (rest rows)))))
-                   (catch Exception err
-                     (s/put! stream (ex->ex-info err {:query statement :values values}))))
-                 (s/close! stream))
+                 (let [rows (codec/result-set->maps (.get rs-future)
+                                                    result-set-fn
+                                                    key-fn)]
+                   (s/connect rows stream)))
                (onFailure [_ ex]
                  (s/put! stream (ex->ex-info ex {:query statement :values values}))
                  (s/close! stream)))


### PR DESCRIPTION
the manifold buffered query implementation times-out because the lazy-seq of all pages of results is consumed synchronously and the attempt to put! all pages of results into the single page of stream buffer fails (unless there is a consumer keeping up presumably)

the PR uses manifold's own mechanism for connecting lazy seqs to stream, which only consumes from the seq when there is space in the stream buffer