### PR TITLE
codec: simplify handing out to map->Record constructors

### DIFF
--- a/modules/alia/src/qbits/alia/codec.clj
+++ b/modules/alia/src/qbits/alia/codec.clj
@@ -57,7 +57,7 @@
   [record-ctor]
   (reify RowGenerator
     (init-row [_] (transient {}))
-    (conj-row [_ row k v] (assoc! row k v))
+    (conj-row [_ row k v] (assoc! row (keyword k) v))
     (finalize-row [_ row] (-> row persistent! record-ctor))))
 
 (defn decode-row


### PR DESCRIPTION
The constructors functions created by `defrecord` expect
keyword keys in the `map->Record` argument.

Without this, `(row-gen->record map->Record)` does not
produce the expected output.