### PR TITLE
Add new policy builder functions for constructing policies from EDN.

### DIFF
--- a/modules/alia/project.clj
+++ b/modules/alia/project.clj
@@ -9,7 +9,8 @@
                   :classifier "shaded"
                   :exclusions [io.netty/*]]
                  [com.datastax.cassandra/dse-driver "1.1.0"
-                  :exclusions [com.datastax.cassandra/cassandra-driver-core]]]
+                  :exclusions [com.datastax.cassandra/cassandra-driver-core]]
+                 [org.hdrhistogram/HdrHistogram "2.1.9"]]
   :jar-exclusions [#"log4j.properties"]
   :codox {:source-uri "https://github.com/mpenet/alia/blob/master/{filepath}#L{line}"
           :metadata {:doc/format :markdown}

--- a/modules/alia/src/qbits/alia/enum.clj
+++ b/modules/alia/src/qbits/alia/enum.clj
@@ -7,11 +7,12 @@
     ConsistencyLevel
     HostDistance
     ProtocolOptions$Compression
-    WriteType)))
+    WriteType)
+   (java.util.concurrent TimeUnit)))
 
 (def write-type (enum/enum->fn WriteType))
 (def consistency-level (enum/enum->fn ConsistencyLevel))
 (def host-distance (enum/enum->fn HostDistance))
 (def compression (enum/enum->fn ProtocolOptions$Compression))
 (def batch-statement-type (enum/enum->fn BatchStatement$Type))
-
+(def time-unit (enum/enum->fn TimeUnit))

--- a/modules/alia/src/qbits/alia/policy/reconnection.clj
+++ b/modules/alia/src/qbits/alia/policy/reconnection.clj
@@ -4,7 +4,8 @@ attempted."
   (:import
    (com.datastax.driver.core.policies
     ConstantReconnectionPolicy
-    ExponentialReconnectionPolicy)))
+    ExponentialReconnectionPolicy
+    Policies)))
 
 (defn constant-reconnection-policy
   "A reconnection policy that waits a constant time between each reconnection
@@ -18,3 +19,25 @@ reconnection attempt (but keeps a constant delay once a maximum delay is
 reached)."
   [base-delay-ms max-delay-ms]
   (ExponentialReconnectionPolicy. base-delay-ms max-delay-ms))
+
+(defmulti make (fn [policy] (or (:type policy) policy)))
+
+(defn map->constant-reconnection-policy
+  [{:keys [constant-delay-ms]}]
+  (constant-reconnection-policy constant-delay-ms))
+
+(defn map->exponential-reconnection-policy
+  [{:keys [base-delay-ms max-delay-ms]}]
+  (exponential-reconnection-policy base-delay-ms max-delay-ms))
+
+(defmethod make :default
+  [_]
+  (Policies/defaultReconnectionPolicy))
+
+(defmethod make :constant
+  [policy]
+  (map->constant-reconnection-policy policy))
+
+(defmethod make :exponential
+  [policy]
+  (map->exponential-reconnection-policy policy))

--- a/modules/alia/src/qbits/alia/policy/retry.clj
+++ b/modules/alia/src/qbits/alia/policy/retry.clj
@@ -139,3 +139,29 @@ exception."
                      (int required-acks)
                      (int received-acks)
                      (int nb-retry))))
+
+(defmulti make (fn [policy] (or (:type policy) policy)))
+
+(defmethod make :default
+  [_]
+  (default-retry-policy))
+
+(defmethod make :fallthrough
+  [_]
+  (fallthrough-retry-policy))
+
+(defmethod make :downgrading
+  [_]
+  (downgrading-consistency-retry-policy))
+
+(defmethod make :logging/default
+  [_]
+  (logging-retry-policy (default-retry-policy)))
+
+(defmethod make :logging/fallthrough
+  [_]
+  (logging-retry-policy (fallthrough-retry-policy)))
+
+(defmethod make :logging/downgrading
+  [_]
+  (logging-retry-policy (downgrading-consistency-retry-policy)))

--- a/modules/alia/src/qbits/alia/policy/speculative_execution.clj
+++ b/modules/alia/src/qbits/alia/policy/speculative_execution.clj
@@ -1,10 +1,15 @@
 (ns qbits.alia.policy.speculative-execution
+  (:require [qbits.alia.enum :as enum])
   (:import
-   (com.datastax.driver.core PerHostPercentileTracker)
+   (com.datastax.driver.core
+    PerHostPercentileTracker
+    ClusterWidePercentileTracker
+    PercentileTracker$Builder)
    (com.datastax.driver.core.policies
     ConstantSpeculativeExecutionPolicy
     NoSpeculativeExecutionPolicy
-    PercentileSpeculativeExecutionPolicy)))
+    PercentileSpeculativeExecutionPolicy
+    Policies)))
 
 (defn constant-speculative-execution-policy
   "A SpeculativeExecutionPolicy that schedules a given number of
@@ -27,3 +32,87 @@
   "A SpeculativeExecutionPolicy that never schedules speculative executions."
   []
   (NoSpeculativeExecutionPolicy/INSTANCE))
+
+(defn percentile-tracker
+  "A `LatencyTracker` that records query latencies over a sliding time interval,
+  and exposes an API to retrieve the latency at a given percentile.
+
+  It uses `HdrHistogram` to record latencies: for each category, there is a
+  \"live\" histogram where current latencies are recorded, and a \"cached\",
+  read-only histogram that is used when clients call
+  `getLatencyAtPercentile(Host, Statement, Exception, double)`. Each time
+  the cached histogram becomes older than the interval, the two histograms
+  are switched. Statistics will not be available during the first interval
+  at cluster startup, since we don't have a cached histogram yet."
+  [^PercentileTracker$Builder builder
+   {:keys [interval min-recorded-values significant-value-digits]}]
+  (let [[interval-value interval-unit] interval]
+    (when interval
+      (.withInterval ^PercentileTracker$Builder builder
+                     ^long (long interval-value)
+                     ^TimeUnit (enum/time-unit interval-unit)))
+    (when min-recorded-values
+      (.withMinRecordedValues ^PercentileTracker$Builder builder
+                              ^int (int min-recorded-values)))
+    (when significant-value-digits
+      (.withNumberOfSignificantValueDigits ^PercentileTracker$Builder builder
+                                           ^int (int significant-value-digits)))
+    (.build ^PercentileTracker$Builder builder)))
+
+(defn cluster-wide-percentile-tracker
+  "A `PercentileTracker` that aggregates all measurements into a single
+  histogram.
+
+  This gives you global latency percentiles for the whole cluster, meaning that
+  latencies of slower hosts will tend to appear in higher percentiles."
+  [{:keys [highest-trackable-latency-millis] :as opts}]
+  (percentile-tracker
+   (ClusterWidePercentileTracker/builder highest-trackable-latency-millis)
+   opts))
+
+(defn per-host-percentile-tracker
+  "A `PercentileTracker` that maintains a separate histogram for each host.
+
+  This gives you per-host latency percentiles, meaning that each host will
+  only be compared to itself."
+  [{:keys [highest-trackable-latency-millis] :as opts}]
+  (percentile-tracker
+   (PerHostPercentileTracker/builder highest-trackable-latency-millis)
+   opts))
+
+(defmulti make (fn [policy] (or (:type policy) policy)))
+
+(defn map->constant-speculative-execution-policy
+  [{:keys [constant-delay-millis max-speculative-executions]}]
+  (constant-speculative-execution-policy constant-delay-millis
+                                         max-speculative-executions))
+
+(defn map->percentile-speculative-execution-policy
+  [tracker {:keys [percentile max-executions]}]
+  (percentile-speculative-execution-policy tracker
+                                           percentile
+                                           max-executions))
+
+(defmethod make :default
+  [_]
+  (Policies/defaultSpeculativeExecutionPolicy))
+
+(defmethod make :none
+  [_]
+  (no-speculative-execution-policy))
+
+(defmethod make :constant
+  [policy]
+  (map->constant-speculative-execution-policy policy))
+
+(defmethod make :cluster-wide-percentile-tracker
+  [policy]
+  (map->percentile-speculative-execution-policy
+   (cluster-wide-percentile-tracker policy)
+   policy))
+
+(defmethod make :per-host-percentile-tracker
+  [policy]
+  (map->percentile-speculative-execution-policy
+   (per-host-percentile-tracker policy)
+   policy))


### PR DESCRIPTION
Add new builder functions to each policy namespace for constructing policies from simple EDN maps/keywords.

Each policy namespace now has a 'make' multimethod to allow for customisation of policy construction.

Update set-cluster-option! implementations to allow further cluster configuration without the need for Java interop.

This should allow cluster config to be largely specified in an EDN file.

Each of the policies load balancing, retry, reconnection and speculative execution may now be optional specified using keywords and option maps.

Also support for the identity address translator was added.

Documentation of the cluster function has been updated to reflect all of the new options.

The HdrHistogram policy dependency has been added to support the percentile speculative execution policies.