### PR TITLE
Improve protocol V1 support

### DIFF
--- a/modules/alia/test/qbits/alia/test/alia.clj
+++ b/modules/alia/test/qbits/alia/test/alia.clj
@@ -1,0 +1,16 @@
+(ns qbits.alia.test.alia
+  "Function tests that don't require a running Cassandra instance"
+  (:require [clojure.test :refer :all]
+            [qbits.alia :refer :all])
+  (:import (com.datastax.driver.core ProtocolVersion SimpleStatement)))
+
+(deftest query->statement-test
+  (is (nil?
+       (-> "use foo;"
+           ^SimpleStatement (query->statement nil nil)
+           (.getValues ProtocolVersion/V1 nil)))
+      "Protocol V1 doesn't support execute with values so values should be nil when not given")
+
+  (is (not (nil? (-> "select * from users where user_name= :name"
+                     ^SimpleStatement (query->statement [nil] {:encoder identity})
+                     (.getValues nil nil))))))

--- a/test/qbits/alia/test/core.clj
+++ b/test/qbits/alia/test/core.clj
@@ -13,7 +13,7 @@
    [qbits.hayt :as h]
    [clojure.core.async :as async])
   (:import
-    (com.datastax.driver.core Statement UDTValue ConsistencyLevel Cluster)))
+    (com.datastax.driver.core UDTValue ConsistencyLevel Cluster)))
 
 (try
   (require 'qbits.alia.spec)


### PR DESCRIPTION
I'm trying to use alia on a cluster running Cassandra 1.2.19. Since this very old version only implements V1 binary protocol, features are quite limited. One of the limitation is execute with values that is not supported.

Thus, when I run `(alia/execute session "use myks;")` I get the following exception:

```
ExceptionInfo Query execution failed {:type :qbits.alia/execute, :exception #error {
 :cause "Unsupported feature with the native protocol V1 (which is currently in use): Binary values are not supported"
 :via
 [{:type com.datastax.driver.core.exceptions.UnsupportedFeatureException
   :message "Unsupported feature with the native protocol V1 (which is currently in use): Binary values are not supported"
   :at [com.datastax.driver.core.SessionManager makeRequestMessage "SessionManager.java" 562]}]
 :trace
 [[com.datastax.driver.core.SessionManager makeRequestMessage "SessionManager.java" 562]
  [com.datastax.driver.core.SessionManager executeAsync "SessionManager.java" 131]
  [com.datastax.driver.core.AbstractSession execute "AbstractSession.java" 68]
  [qbits.alia$execute invokeStatic "alia.clj" 502]
  [qbits.alia$execute invoke "alia.clj" 444]
  [qbits.alia$execute invokeStatic "alia.clj" 510]
  [qbits.alia$execute invoke "alia.clj" 444]
  [user$eval3115 invokeStatic "9f570ec79aa6a18cfdc19c7a8bd89728957c6a02-init.clj" 1]
  [user$eval3115 invoke "9f570ec79aa6a18cfdc19c7a8bd89728957c6a02-init.clj" 1]
  [clojure.lang.Compiler eval "Compiler.java" 7062]
  [clojure.lang.Compiler eval "Compiler.java" 7025]
  [clojure.core$eval invokeStatic "core.clj" 3206]
  [clojure.core$eval invoke "core.clj" 3202]
```

This PR changes the construction of SimpleStatement to *not* pass an empty values objects when there are no values specified. This way, it is compatible with Cassandra 1.2.

Since I just only started using alia on this cluster there may be other elements to adapt later on.

I've added a unit test directly within the `alia` module as you suggested.