### PR TITLE
Remove superfluous type hints within qbits.alia.policy.speculative-execution

### DIFF
--- a/modules/alia/src/qbits/alia/policy/load_balancing.clj
+++ b/modules/alia/src/qbits/alia/policy/load_balancing.clj
@@ -8,7 +8,6 @@
     TokenAwarePolicy
     WhiteListPolicy
     LatencyAwarePolicy
-    LatencyAwarePolicy$Builder
     Policies)
    (java.net
     InetSocketAddress
@@ -71,7 +70,7 @@
 
   http://www.datastax.com/drivers/java/apidocs/com/datastax/driver/core/policies/DCAwareRoundRobinPolicy.html"
   ([dc used-hosts-per-remote-dc]
-   (let [b (-> (DCAwareRoundRobinPolicy/builder))]
+   (let [b (DCAwareRoundRobinPolicy/builder)]
      (.withLocalDc b dc)
      (when used-hosts-per-remote-dc
        (.withUsedHostsPerRemoteDc b (int used-hosts-per-remote-dc)))

--- a/modules/alia/src/qbits/alia/policy/speculative_execution.clj
+++ b/modules/alia/src/qbits/alia/policy/speculative_execution.clj
@@ -48,16 +48,12 @@
    {:keys [interval min-recorded-values significant-value-digits]}]
   (let [[interval-value interval-unit] interval]
     (when interval
-      (.withInterval ^PercentileTracker$Builder builder
-                     ^long (long interval-value)
-                     ^TimeUnit (enum/time-unit interval-unit)))
+      (.withInterval builder (long interval-value) (enum/time-unit interval-unit)))
     (when min-recorded-values
-      (.withMinRecordedValues ^PercentileTracker$Builder builder
-                              ^int (int min-recorded-values)))
+      (.withMinRecordedValues builder(int min-recorded-values)))
     (when significant-value-digits
-      (.withNumberOfSignificantValueDigits ^PercentileTracker$Builder builder
-                                           ^int (int significant-value-digits)))
-    (.build ^PercentileTracker$Builder builder)))
+      (.withNumberOfSignificantValueDigits builder (int significant-value-digits)))
+    (.build builder)))
 
 (defn cluster-wide-percentile-tracker
   "A `PercentileTracker` that aggregates all measurements into a single


### PR DESCRIPTION
I couldn't resist. Those type hints are superfluous as the invoked java methods all have a single occurence, thus clojure can infer the type based on the method signature directly.