### PR TITLE
Add ssl-protocol to ssl-options.

### DIFF
--- a/modules/alia-spec/src/qbits/alia/spec.clj
+++ b/modules/alia-spec/src/qbits/alia/spec.clj
@@ -174,6 +174,7 @@
          'cluster-options.ssl-options)
 (s/def ::cluster-options.ssl-options/keystore-path string?)
 (s/def ::cluster-options.ssl-options/keystore-password string?)
+(s/def ::cluster-options.ssl-options/ssl-protocol string?)
 (s/def ::cluster-options.ssl-options/cipher-suites (s/coll-of string? :min-count 1))
 
 (s/def ::cluster-options/ssl-options
@@ -182,6 +183,7 @@
         (s/keys :opt-un
                 [::cluster-options.ssl-options/keystore-path
                  ::cluster-options.ssl-options/keystore-password
+                 ::cluster-options.ssl-options/ssl-protocol
                  ::cluster-options.ssl-options/cipher-suites])))
 
 (s/def ::cluster-options/timestamp-generator

--- a/modules/alia/src/qbits/alia.clj
+++ b/modules/alia/src/qbits/alia.clj
@@ -168,7 +168,7 @@
 * `:ssl-options` : advanced SSL setup using a
   `com.datastax.driver.core.SSLOptions` instance or a map of
   `:keystore-path`, `:keystore-password` and optional
-  `:ssl-protcol`, `:cipher-suites`.  This provides a path/pwd to a
+  `:ssl-protocol`, `:cipher-suites`.  This provides a path/pwd to a
   [KeyStore](http://docs.oracle.com/javase/7/docs/api/java/security/KeyStore.html)
   that can ben generated
   with [keytool](http://docs.oracle.com/javase/7/docs/technotes/tools/solaris/keytool.html)

--- a/modules/alia/src/qbits/alia.clj
+++ b/modules/alia/src/qbits/alia.clj
@@ -168,10 +168,12 @@
 * `:ssl-options` : advanced SSL setup using a
   `com.datastax.driver.core.SSLOptions` instance or a map of
   `:keystore-path`, `:keystore-password` and optional
-  `:cipher-suites`.  This provides a path/pwd to a
+  `:ssl-protcol`, `:cipher-suites`.  This provides a path/pwd to a
   [KeyStore](http://docs.oracle.com/javase/7/docs/api/java/security/KeyStore.html)
   that can ben generated
   with [keytool](http://docs.oracle.com/javase/7/docs/technotes/tools/solaris/keytool.html)
+  Overriding default ssl protocol is supported via `:ssl-protocol`,
+  which accepts a string like - TLSv1.2
   Overriding default cipher suites is supported via `:cipher-suites`,
   which accepts a sequence of Strings.
 

--- a/modules/alia/src/qbits/alia/cluster_options.clj
+++ b/modules/alia/src/qbits/alia/cluster_options.clj
@@ -191,9 +191,9 @@
   (.withSSL builder
             (if (instance? SSLOptions ssl-options)
               ssl-options
-              (let [{:keys [keystore-path keystore-password cipher-suites]} ssl-options
+              (let [{:keys [keystore-path keystore-password ssl-protocol cipher-suites]} ssl-options
                     keystore (KeyStore/getInstance "JKS")
-                    ssl-context (SSLContext/getInstance "SSL")
+                    ssl-context (SSLContext/getInstance (or ssl-protocol "SSL"))
                     keymanager (KeyManagerFactory/getInstance (KeyManagerFactory/getDefaultAlgorithm))
                     trustmanager (TrustManagerFactory/getInstance (TrustManagerFactory/getDefaultAlgorithm))
                     password (char-array keystore-password)]


### PR DESCRIPTION
I need to be able to set the [ssl protocol](https://docs.oracle.com/javase/8/docs/api/javax/net/ssl/SSLContext.html#getInstance-java.lang.String-) specifically in our use case. This fix allows setting the protocol on creation of the SSLContext.