### PR TITLE
alia-component: test if the sessions and the cluster exist

### DIFF
--- a/modules/alia-component/src/qbits/alia/component.clj
+++ b/modules/alia-component/src/qbits/alia/component.clj
@@ -104,10 +104,12 @@
     (let [clusters (reduce-kv #(assoc %1 %2 (alia/cluster %3)) {} configs)]
       (assoc this :clusters clusters :sessions (atom []))))
   (stop [this]
-    (doseq [^com.datastax.driver.core.Session session @sessions]
-      (.close session))
-    (doseq [[_ cluster] clusters]
-      (.close ^com.datastax.driver.core.Cluster cluster))
+    (when (some? sessions)
+      (doseq [^com.datastax.driver.core.Session session @sessions]
+        (.close session)))
+    (when (some? clusters)
+      (doseq [[_ cluster] clusters]
+        (.close ^com.datastax.driver.core.Cluster cluster)))
     (assoc this :clusters nil :sessions nil)))
 
 (defn cassandra-registry


### PR DESCRIPTION
The `stop` function should be idempotent, as described in the
component
documentation (https://github.com/stuartsierra/component#idempotence).

This commit checks if the sessions and the clusters are defined before
closing them.