### PR TITLE
component: ensure spec is present

### DIFF
--- a/modules/alia-component/project.clj
+++ b/modules/alia-component/project.clj
@@ -6,5 +6,6 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure ~clj-version]
                  [com.stuartsierra/component "0.3.2"]
-                 [cc.qbits/alia ~alia-version]]
+                 [cc.qbits/alia ~alia-version]
+                 [cc.qbits/alia-spec ~alia-version]]
   :global-vars {*warn-on-reflection* true})

--- a/modules/alia-component/src/qbits/alia/component.clj
+++ b/modules/alia-component/src/qbits/alia/component.clj
@@ -13,7 +13,8 @@
    See `query-functions` for details on how to use it."
   (:require [com.stuartsierra.component :as component]
             [clojure.spec.alpha         :as s]
-            [qbits.alia                 :as alia]))
+            [qbits.alia                 :as alia]
+            qbits.alia.spec))
 
 (defn keyspace-session
   "Retrieve a `Session` instance set to use a specific keyspace.


### PR DESCRIPTION
Previously, `qbits.alia.component` relied on `qbits.alia.spec` without requiring it.
Since the spec assertions are done at component build time, not runtime, there's a case for switching to throwing exceptions instead of asserting.