### PR TITLE
5.0.0 fix memory leak

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,0 +1,4 @@
+{:lint-as {qbits.alia/when-opt clojure.core/when
+           manifold.deferred/loop clojure.core/loop}
+ :linters {:unresolved-symbol
+           {:exclude [(qbits.alia/when-opt)]}}}

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ pom.xml
 .idea
 .lein-env
 /bench.clj
+/.clj-kondo/.cache
+/.clj-kondo/cache

--- a/modules/alia-manifold/src/qbits/alia/manifold.clj
+++ b/modules/alia-manifold/src/qbits/alia/manifold.clj
@@ -115,7 +115,7 @@
    (execute-stream-pages session query {})))
 
 
-(defn ^:private safe-identity
+(defn ^:private coerce-seq
   "if the page should happen to be an Exception, wrap
    it in a vector so that it can be concatenated to the
    value stream"
@@ -129,7 +129,7 @@
 
     (s/connect-via
      stream-s
-     #(s/put-all! out %)
+     #(s/put-all! out (coerce-seq %))
      out)
 
     out))

--- a/modules/alia-manifold/src/qbits/alia/manifold.clj
+++ b/modules/alia-manifold/src/qbits/alia/manifold.clj
@@ -122,16 +122,26 @@
   [v]
   (if (sequential? v) v [v]))
 
+(defn concat-seq-s
+  "concat a stream of seqs onto a stream of plain values"
+  [stream-s]
+  (let [out (s/stream)]
+
+    (s/connect-via
+     stream-s
+     #(s/put-all! out %)
+     out)
+
+    out))
+
 (defn execute-stream
   "like `execute-stream-pages`, but returns a `Stream<row>`
 
    supports all the args of `execute-stream-pages`"
   ([^CqlSession session query {:as opts}]
-   (let [stream (execute-stream-pages session query opts)]
+   (let [page-s (execute-stream-pages session query opts)]
 
-     (s/transform
-      (mapcat safe-identity)
-      stream)))
+     (concat-seq-s page-s)))
 
   ([^CqlSession session query]
    (execute-stream session query {})))

--- a/modules/alia/src/qbits/alia/completable_future.clj
+++ b/modules/alia/src/qbits/alia/completable_future.clj
@@ -27,13 +27,13 @@
     (or (ex-cause ex) ex)
     ex))
 
-(defn handle-completion-stage*
+(defn handle-completion-stage
   "java incantation to handle both branches of a completion-stage"
   ([^CompletionStage completion-stage
     on-success
     on-error
     {^Executor executor :executor
-     :as opts}]
+     :as _opts}]
    (let [handler-bifn (reify BiFunction
                         (apply [_ r ex]
                           (if (some? ex)
@@ -46,26 +46,4 @@
   ([^CompletionStage completion-stage
     on-success
     on-error]
-   (handle-completion-stage* completion-stage on-success on-error {})))
-
-(defmacro handle-completion-stage
-  "handle both branches of a completion stage
-
-   it's a macro to capture any exceptions from the completion-stage
-   form and also send them through the `on-error` handler"
-  ([completion-stage
-    on-success
-    on-error
-    opts]
-   `(try
-      (handle-completion-stage* ~completion-stage ~on-success ~on-error ~opts)
-      (catch Exception e#
-        (handle-completion-stage*
-         (failed-future (ex-unwrap e#))
-         ~on-success
-         ~on-error
-         ~opts))))
-  ([completion-stage
-    on-success
-    on-error]
-   `(handle-completion-stage ~completion-stage ~on-success ~on-error {})))
+   (handle-completion-stage completion-stage on-success on-error {})))

--- a/modules/alia/src/qbits/alia/completable_future.clj
+++ b/modules/alia/src/qbits/alia/completable_future.clj
@@ -1,11 +1,11 @@
 (ns qbits.alia.completable-future
+  (:require
+   [qbits.alia.error :as err])
   (:import
    [java.util.concurrent
     Executor
     CompletionStage
-    CompletableFuture
-    ExecutionException
-    CompletionException]
+    CompletableFuture]
    [java.util.function BiFunction]))
 
 (defn completed-future
@@ -19,14 +19,6 @@
     (.completeExceptionally f e)
     f))
 
-(defn ex-unwrap
-  "Unwraps exceptions if we have a valid ex-cause present"
-  [ex]
-  (if (or (instance? ExecutionException ex)
-          (instance? CompletionException ex))
-    (or (ex-cause ex) ex)
-    ex))
-
 (defn handle-completion-stage
   "java incantation to handle both branches of a completion-stage"
   ([^CompletionStage completion-stage
@@ -37,7 +29,7 @@
    (let [handler-bifn (reify BiFunction
                         (apply [_ r ex]
                           (if (some? ex)
-                            (on-error (ex-unwrap ex))
+                            (on-error (err/ex-unwrap ex))
                             (on-success r))))]
 
      (if (some? executor)

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cc.qbits/alia-all "5.0.0-alpha7-SNAPSHOT"
+(defproject cc.qbits/alia-all "5.0.0-alpha7"
   :description "Cassandra CQL3 client for Clojure - datastax/java-driver wrapper"
   :url "https://github.com/mpenet/alia"
   :scm {:name "git"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cc.qbits/alia-all "5.0.0-alpha1-SNAPSHOT"
+(defproject cc.qbits/alia-all "5.0.0-alpha7-SNAPSHOT"
   :description "Cassandra CQL3 client for Clojure - datastax/java-driver wrapper"
   :url "https://github.com/mpenet/alia"
   :scm {:name "git"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cc.qbits/alia-all "5.0.0"
+(defproject cc.qbits/alia-all "5.0.0-alpha1-SNAPSHOT"
   :description "Cassandra CQL3 client for Clojure - datastax/java-driver wrapper"
   :url "https://github.com/mpenet/alia"
   :scm {:name "git"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cc.qbits/alia-all "5.0.0-alpha6-SNAPSHOT"
+(defproject cc.qbits/alia-all "5.0.0-alpha6"
   :description "Cassandra CQL3 client for Clojure - datastax/java-driver wrapper"
   :url "https://github.com/mpenet/alia"
   :scm {:name "git"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cc.qbits/alia-all "5.0.0-alpha5-SNAPSHOT"
+(defproject cc.qbits/alia-all "5.0.0-alpha5"
   :description "Cassandra CQL3 client for Clojure - datastax/java-driver wrapper"
   :url "https://github.com/mpenet/alia"
   :scm {:name "git"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cc.qbits/alia-all "5.0.0-alpha4"
+(defproject cc.qbits/alia-all "5.0.0-alpha5-SNAPSHOT"
   :description "Cassandra CQL3 client for Clojure - datastax/java-driver wrapper"
   :url "https://github.com/mpenet/alia"
   :scm {:name "git"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cc.qbits/alia-all "5.0.0-alpha7"
+(defproject cc.qbits/alia-all "5.0.0-alpha8-SNAPSHOT"
   :description "Cassandra CQL3 client for Clojure - datastax/java-driver wrapper"
   :url "https://github.com/mpenet/alia"
   :scm {:name "git"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cc.qbits/alia-all "5.0.0-alpha5"
+(defproject cc.qbits/alia-all "5.0.0-alpha6-SNAPSHOT"
   :description "Cassandra CQL3 client for Clojure - datastax/java-driver wrapper"
   :url "https://github.com/mpenet/alia"
   :scm {:name "git"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cc.qbits/alia-all "5.0.0-alpha6"
+(defproject cc.qbits/alia-all "5.0.0"
   :description "Cassandra CQL3 client for Clojure - datastax/java-driver wrapper"
   :url "https://github.com/mpenet/alia"
   :scm {:name "git"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cc.qbits/alia-all "5.0.0-alpha4-SNAPSHOT"
+(defproject cc.qbits/alia-all "5.0.0-alpha4"
   :description "Cassandra CQL3 client for Clojure - datastax/java-driver wrapper"
   :url "https://github.com/mpenet/alia"
   :scm {:name "git"


### PR DESCRIPTION
yapster APIs and streaming processes were leaking - OOMEing over a couple of days (of low traffic on internal dev instances)

investigation showed lots of our `EntityInstance` db records referenced from the global downstream graph metadata in `manifold.stream.graph/handle->downstreams`

this was something of a mysterious issue, in that usually stream-related leaks are because some streams are not being closed, and things stop working because streams are not closed and `stream/reduce`s don't terminate - but in this case streams were apparently being closed and correct operation of the system was observed

two issues were found which are fixed in this PR

1. [qbits.alia.manifold/handle-page-completion-stage](https://github.com/mpenet/alia/blob/5.0.0-fix-memory-leak/modules/alia-manifold/src/qbits/alia/manifold.clj#L13) recurses to fetch the next page. since manifold often uses the caller thread for callbacks, this could blow the stack, so it has been changed to use `deferred/loop`
2. [qbits.alia.manifold/execute-stream](https://github.com/mpenet/alia/blob/5.0.0-fix-memory-leak/modules/alia-manifold/src/qbits/alia/manifold.clj#L137) was using a `(stream/transform (mapcat identity) <page-stream>)` to concatenate pages from the page-stream on to a record-stream. this appears to be responsible for the leak ([replacement](https://github.com/mpenet/alia/blob/5.0.0-fix-memory-leak/modules/alia-manifold/src/qbits/alia/manifold.clj#L125) of the `stream/transform` has fixed the leak)