### PR TITLE
Include namespace in bound keywords

### DIFF
--- a/modules/alia/src/qbits/alia.clj
+++ b/modules/alia/src/qbits/alia.clj
@@ -85,7 +85,7 @@
          (doseq [[k x] values]
            (settable-by-name/set-named-parameter!
             builder
-            (name k)
+            (if (keyword? k) (str (.-sym k)) k)
             (encoder x)))
          (.build builder))
        (.bind statement (to-array (map encoder values))))


### PR DESCRIPTION
closes https://github.com/mpenet/alia/issues/118

Tested for a while now. I think this is the fastest way to strip the colon from a keyword.